### PR TITLE
fix: remove component prefix from release tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary
- `release-please-config.json` に `"include-component-in-tag": false` を追加
- タグ形式が `pluckvocab-v1.0.0` → `v1.0.0` になり、`release.yml` の `v*` トリガーにマッチするようになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)