### PR TITLE
docs: add README.md and MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Kinji Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# PluckVocab
+
+Pluck words from any page to build your vocabulary.
+
+## Install
+
+Coming soon on the Chrome Web Store.
+
+## Usage
+
+1. Select a word on any webpage
+2. Right-click and choose **Pluck "\<word\>"**
+3. Open the popup to see your vocabulary
+
+## Development
+
+### Setup
+
+```sh
+bun install
+bun run build
+bun run open    # launch chromium with extension loaded
+```
+
+### Scripts
+
+| Script | Description |
+|---|---|
+| `bun run build` | Production build |
+| `bun run dev` | Watch mode |
+| `bun run open` | Launch Chromium with extension loaded |
+| `bun run lint` | Lint with Biome |
+| `bun run lint:fix` | Lint and auto-fix |
+| `bun run format` | Format with Biome |
+| `bun run typecheck` | Type check with tsc |
+| `bun run test:e2e` | Run Playwright E2E tests |
+| `bun run zip` | Package `dist/` into `pluckvocab.zip` |
+
+Architecture decisions are recorded in [`docs/adr/`](docs/adr/).
+
+## Roadmap
+
+- [x] Pluck words from any page via context menu
+- [ ] Export / import vocabulary
+- [ ] Word definitions via dictionary API
+- [ ] Spaced repetition review
+- [ ] Firefox support
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Add README.md with install, usage, development setup, scripts, roadmap, and license sections
- Add MIT LICENSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)