### PR TITLE
ci: add unit test job to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,20 @@ jobs:
           fail-on-cache-miss: true
       - run: bun run lint
 
+  unit:
+    needs: install
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: deps-${{ hashFiles('bun.lockb') }}
+          fail-on-cache-miss: true
+      - run: bun run test:unit
+
   build:
     needs: install
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ bun run open    # launch chromium with extension loaded
 | `bun run lint:fix` | Lint and auto-fix |
 | `bun run format` | Format with Biome |
 | `bun run typecheck` | Type check with tsc |
+| `bun run test:unit` | Run unit tests |
 | `bun run test:e2e` | Run Playwright E2E tests |
 | `bun run zip` | Package `dist/` into `pluckvocab.zip` |
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "bunx biome format --write .",
     "typecheck": "bunx tsc --noEmit",
     "zip": "cd dist && zip -r ../pluckvocab.zip .",
+    "test:unit": "bun test tests/unit/",
     "test:e2e": "playwright test",
     "open": "bun run scripts/open-browser.ts"
   },


### PR DESCRIPTION
## Summary
- Add `test:unit` script to package.json (`bun test tests/unit/`)
- Add `unit` job to CI workflow (parallel with typecheck, lint, build, e2e)
- Add `test:unit` to README scripts table


🤖 Generated with [Claude Code](https://claude.com/claude-code)